### PR TITLE
Preserve parameter inference

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ export type NoInfer<T> = [T][T extends any ? 0 : never];
  * Adapted from type-fest's PartialDeep
  */
 export type PartialDeep<T> = T extends (...args: infer P) => infer R
-  ? (((...args: P) => PartialDeep<R>) & PartialDeepObject<T>) | undefined
+  ? ((...args: P) => PartialDeep<R> | void & PartialDeepObject<T>) | undefined
   : T extends object
   ? T extends ReadonlyArray<infer ItemType> // Test for arrays/tuples, per https://github.com/microsoft/TypeScript/issues/35156
     ? ItemType[] extends T // Test for arrays (non-tuples) specifically

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ export type NoInfer<T> = [T][T extends any ? 0 : never];
  * Adapted from type-fest's PartialDeep
  */
 export type PartialDeep<T> = T extends (...args: infer P) => infer R
-  ? ((...args: P) => PartialDeep<R> | void & PartialDeepObject<T>) | undefined
+  ? ((...args: P) => PartialDeep<R> | void) & PartialDeepObject<T> | undefined
   : T extends object
   ? T extends ReadonlyArray<infer ItemType> // Test for arrays/tuples, per https://github.com/microsoft/TypeScript/issues/35156
     ? ItemType[] extends T // Test for arrays (non-tuples) specifically

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ export type NoInfer<T> = [T][T extends any ? 0 : never];
  * Adapted from type-fest's PartialDeep
  */
 export type PartialDeep<T> = T extends (...args: infer P) => infer R
-  ? ((...args: P) => PartialDeep<R> | void) & PartialDeepObject<T> | undefined
+  ? ((...args: P) => PartialDeep<R> | void) & PartialDeepObject<T> | PartialDeepObject<T> | undefined
   : T extends object
   ? T extends ReadonlyArray<infer ItemType> // Test for arrays/tuples, per https://github.com/microsoft/TypeScript/issues/35156
     ? ItemType[] extends T // Test for arrays (non-tuples) specifically

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,8 +3,8 @@ export type NoInfer<T> = [T][T extends any ? 0 : never];
 /**
  * Adapted from type-fest's PartialDeep
  */
-export type PartialDeep<T> = T extends (...args: any[]) => any
-  ? PartialDeepObject<T> | undefined
+export type PartialDeep<T> = T extends (...args: infer P) => infer R
+  ? (((...args: P) => PartialDeep<R>) & PartialDeepObject<T>) | undefined
   : T extends object
   ? T extends ReadonlyArray<infer ItemType> // Test for arrays/tuples, per https://github.com/microsoft/TypeScript/issues/35156
     ? ItemType[] extends T // Test for arrays (non-tuples) specifically

--- a/tests/fromPartial.test.ts
+++ b/tests/fromPartial.test.ts
@@ -93,4 +93,17 @@ describe("fromPartial", () => {
       }),
     );
   });
+
+  it("Can handle deeply recursive partial types", () => {
+    interface RecursiveInterface {
+      (bar: string) : RecursiveInterface;
+      foo: {
+        deepProperty: string
+      },
+    }
+    accept<RecursiveInterface>(
+        fromPartial(bar => (bar2)=> ({})),
+    );
+  });
+  
 });

--- a/tests/fromPartial.test.ts
+++ b/tests/fromPartial.test.ts
@@ -69,6 +69,10 @@ describe("fromPartial", () => {
   it("Should accept functions", () => {
     accept<() => void>(fromPartial({}));
   });
+  
+  it("Should deeply infer types from functions", () => {
+    accept<(foo: string) => (bar: number) => {baz: string}>(fromPartial((foo) => (bar) => {}));
+  });
 
   it("Should accept interfaces which combine object properties and a call signature", () => {
     accept<{

--- a/tests/fromPartial.test.ts
+++ b/tests/fromPartial.test.ts
@@ -94,7 +94,7 @@ describe("fromPartial", () => {
     );
   });
 
-  it("Can handle deeply recursive partial types", () => {
+  it("Should handle deeply recursive partial types", () => {
     interface RecursiveInterface {
       (bar: string) : RecursiveInterface;
       foo: {


### PR DESCRIPTION
Hey there. Great library. I've been using it to help speed up converting an old legacy codebase that had a ton of shady `as any` casting.

One corner case I ran into:

```
interface SomeInterface {
  setter: (p: number) => number;
  value: number;
}

const test: SomeInterface = fromPartial({ setter: (p) => p + 1 });
```

Will throw `TS7006: Parameter 'p' implicitly has an 'any' type` when it could have been inferred. 

Adding an inference for the parameter seems to have fixed it without breaking the rest of my tests. Not sure if it will cover all your use cases as well.

Cheers