### PR TITLE
Add package.json repository/bugs fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,13 @@
   "keywords": [],
   "author": "Matt Pocock",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/total-typescript/shoehorn.git",
+  },
+  "bugs": {
+    "url": "https://github.com/total-typescript/shoehorn/issues"
+  },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.4.2",
     "@changesets/cli": "^2.26.0",


### PR DESCRIPTION
Afaik it makes it convenient to have a link appear on npm here:

![CleanShot 2024-02-26 at 15 42 44](https://github.com/total-typescript/shoehorn/assets/749374/1b1b4e9e-487a-4bf6-af5d-1223bb671e40)
